### PR TITLE
Manage db config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
+## 0.2.0-alpha.1 (:construction: 2019-10-04)
+
+### Changed
+
+- :recycle: Refactor the HRSWP Sqlsrv DB connector class (`MSSQL_DB`) to use its own dedicated database config file and store database connection details as a class property array instead of as globals and to only prepare those connections on initialization instead of immediately connecting to a given database. The connect method will now use the class `datasets` property array.
+
+### Added
+
+- Method to save database connection details in the plugin config file as a class property array.
+- Method to check for the database connections config file and display an admin notice (and a frontend error if debugging is enabled) if it's missing.
+- :lock: A sample configuration file to store database connection details. This file should be treated like the 'wp-config' file: placed in the same directory (either root or one level above) and given restricted permissions (400 or 440).
+
+### Removed
+
+- HRSWP Sqlsrv DB connector class (`MSSQL_DB`) properties for individual databases in favor of a `datasets` array.
+
 ## 0.1.0 (2019-10-01)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,19 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
-## 0.2.0-alpha.1 (:construction: 2019-10-04)
+## 0.2.0-alpha.2 (:construction: 2019-10-09)
 
 ### Changed
 
+- Don't require a database connection for escaping a MS SQL string since we're not using the SQLSRV method to do so.
 - :recycle: Refactor the HRSWP Sqlsrv DB connector class (`MSSQL_DB`) to use its own dedicated database config file and store database connection details as a class property array instead of as globals and to only prepare those connections on initialization instead of immediately connecting to a given database. The connect method will now use the class `datasets` property array.
 
 ### Added
 
+- :sparkles: Add methods to MS SQL Query class to parse query variables into a database request and to get records from a database.
+- Method to retrieve a database name given a table has been assigned.
+- Method to retrieve a database table name given its label.
+- Method to save database table details, including name and associated database, as a class property.
 - Method to save database connection details in the plugin config file as a class property array.
 - Method to check for the database connections config file and display an admin notice (and a frontend error if debugging is enabled) if it's missing.
 - :lock: A sample configuration file to store database connection details. This file should be treated like the 'wp-config' file: placed in the same directory (either root or one level above) and given restricted permissions (400 or 440).

--- a/hrswp-sqlsrv-config-sample.php
+++ b/hrswp-sqlsrv-config-sample.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * The base configuration for the HRSWP Sqlsrv DB plugin.
+ *
+ * This file should be installed alongside the 'wp-config.php' file (either at
+ * root or one level above) and should share its restricted access (400 or
+ * 440 permission).
+ *
+ * This file contains the following configurations:
+ *
+ * - SQL Server settings
+ *
+ * @package HRSWP_Sqlsrv_DB
+ */
+
+/*
+ * *** SAMPLE FILE ***
+ *
+ * To use:
+ *
+ *   1. Update this file with the desired server settings
+ *   2. Rename to 'hrswp-sqlsrv-config.php'.
+ *   3. Move to the same directory as the 'wp-config.php' file.
+ */
+
+/**
+ * EXAMPLE: Defining a database
+ *
+ * $this->add_database(
+ *     'database-handle',                               // A reference name for accessing this database, between 1 and 20 characters in length. Allowed characters: Lowercase alphanumeric characters, dashes and underscores, @see sanitize_key().
+ *     array(
+ *         'mssql_db_name'     => 'database_name_here', // The name of the database to connect to.
+ *         'mssql_db_user'     => 'username_here',      // The Microsoft SQL Server user for the database.
+ *         'mssql_db_password' => 'password_here',      // The Microsoft SQL Server user password.
+ *         'mssql_db_host'     => 'host_here',          // The Microsoft SQL Server host.
+ *     )
+ * );
+ */
+
+/**
+ * EXAMPLE: Associating tables with databases
+ *
+ * $this->set_table_names(
+ *     'database-handle',                             // The reference name of the database containing the table(s).
+ *     array(                                         // An array of one or more tables, each defined as its own array.
+ *         array(
+ *             'label'      => 'table-label',         // A reference name for referring to this table. Allowed characters: Lowercase alphanumeric characters, dashes and underscores, @see sanitize_key().
+ *             'table_name' => 'database_table_name', // The name of the table in the database.
+ *         ),
+ *         array(
+ *             'label'      => 'table-label-2',
+ *             'table_name' => 'another_table',
+ *         ),
+ *     )
+ * );
+ */
+
+// ** Microsoft SQL Server Configuration ** //
+
+// Add your databases and define your tables here.

--- a/hrswp-sqlsrv-db.php
+++ b/hrswp-sqlsrv-db.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: HRSWP Sqlsrv DB
-Version: 0.1.0
+Version: 0.2.0-alpha.1
 Description: A WSU HRS WordPress plugin to connect to and query external Microsoft SQL Server databases.
 Author: Adam Turner, washingtonstateuniversity
 Author URI: https://hrs.wsu.edu/

--- a/hrswp-sqlsrv-db.php
+++ b/hrswp-sqlsrv-db.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: HRSWP Sqlsrv DB
-Version: 0.2.0-alpha.1
+Version: 0.2.0-alpha.2
 Description: A WSU HRS WordPress plugin to connect to and query external Microsoft SQL Server databases.
 Author: Adam Turner, washingtonstateuniversity
 Author URI: https://hrs.wsu.edu/

--- a/includes/class-mssql-db.php
+++ b/includes/class-mssql-db.php
@@ -74,7 +74,7 @@ class MSSQL_DB {
 	 * @since 0.2.0
 	 * @var array
 	 */
-	protected $datasets = array();
+	protected $databases = array();
 
 	/**
 	 * The SQL Server database tables.
@@ -152,7 +152,7 @@ class MSSQL_DB {
 	 * @since 0.2.0
 	 *
 	 * @param string $slug                 Required. A reference name for accessing this dataset.
-	 * @param array  $dataset_config {
+	 * @param array  $database_config {
 	 *     Required. Array of SQL Server database connection details.
 	 *
 	 *     @type string $mssql_db_name     The name of the database to connect to.
@@ -161,14 +161,14 @@ class MSSQL_DB {
      *     @type string $mssql_db_host     The Microsoft SQL Server host.
 	 * }
 	 */
-	private function add_dataset( $slug, $dataset_config ) {
-		if ( empty( $slug ) || ! is_array( $dataset_config ) ) {
+	private function add_database( $slug, $database_config ) {
+		if ( empty( $slug ) || ! is_array( $database_config ) ) {
 			$this->print_error(	__( 'There is a problem with one of the datasets in "hrswp-sqlsrv-config.php."' ) );
 		}
 
 		$slug = sanitize_key( $slug );
 
-		$this->datasets[$slug] = $dataset_config;
+		$this->databases[ $slug ] = $database_config;
 	}
 
 	/**
@@ -181,22 +181,22 @@ class MSSQL_DB {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string $dataset Required. The handle corresponding to the database to connect to.
+	 * @param string $database Required. The handle corresponding to the database to connect to.
 	 * @return bool True with a successful connection, false on failure.
 	 */
-	public function mssql_db_connect( $dataset ) {
+	public function mssql_db_connect( $database ) {
 		// Set the MS SQL Server-style query parameters.
 		$params = array(
-			'Database' => $this->datasets[$dataset]['mssql_db_name'],
-			'Uid'      => $this->datasets[$dataset]['mssql_db_user'],
-			'PWD'      => $this->datasets[$dataset]['mssql_db_password'],
+			'Database' => $this->databases[ $database ]['mssql_db_name'],
+			'Uid'      => $this->databases[ $database ]['mssql_db_user'],
+			'PWD'      => $this->databases[ $database ]['mssql_db_password'],
 		);
 
 		// Open a MS SQL connection using ODBC.
 		if ( $this->show_errors ) {
-			$this->dbh = sqlsrv_connect( $this->datasets[$dataset]['mssql_db_host'], $params );
+			$this->dbh = sqlsrv_connect( $this->databases[ $database ]['mssql_db_host'], $params );
 		} else {
-			$this->dbh = @sqlsrv_connect( $this->datasets[$dataset]['mssql_db_host'], $params ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$this->dbh = @sqlsrv_connect( $this->databases[ $database ]['mssql_db_host'], $params ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		}
 
 		// Check for a successful connection. Return false on error.

--- a/includes/class-mssql-db.php
+++ b/includes/class-mssql-db.php
@@ -177,6 +177,48 @@ class MSSQL_DB {
 	}
 
 	/**
+	 * Associates tables with databases and reference handles for selection.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string $database_handle Required. The reference name of the database containing the table(s).
+	 * @param array  $tables {
+	 *     Required. Array of SQL Server database table labels and table names.
+	 *
+	 *     @type array {
+	 *         Each table should be defined in an array with a label and the database name.
+	 *
+	 *         @type string $label      Required. A reference name for referring to this table.
+	 *                                  Allowed characters: Lowercase alphanumeric characters,
+	 *                                  dashes and underscores, @see sanitize_key().
+	 *         @type string $table_name Required. The name of the table in the database.
+	 *     }
+	 * }
+	 */
+	private function set_table_names( $database_handle, $tables = array() ) {
+		if ( ! array_key_exists( $database_handle, $this->databases ) ) {
+			$this->print_error(
+				sprintf(
+					/* translators: %s: the database identifier */
+					__( 'Problem in MSSQL_DB->add_tables. The database slug %s does not exist.' ),
+					esc_html( $database_handle )
+				)
+			);
+			return;
+		}
+
+		foreach ( $tables as $table ) {
+			// Sanitize the table label.
+			$label = sanitize_key( $table['label'] );
+
+			$this->tables[ $label ] = array(
+				'table_name' => $table['table_name'],
+				'database'   => $database_handle,
+			);
+		}
+	}
+
+	/**
 	 * Connects to a database server and selects a database.
 	 *
 	 * Uses the `sqlsrv` PHP extension to open a connection to a Microsoft SQL

--- a/includes/class-mssql-db.php
+++ b/includes/class-mssql-db.php
@@ -363,15 +363,9 @@ class MSSQL_DB {
 	 * @return string Escaped string.
 	 */
 	private function mssql_escape_string( $string ) {
-		if ( $this->dbh ) {
-			// MS SQL syntax requires single quotes to be escaped.
-			$escaped = str_replace( "'", "''", $string );
-			$escaped = addslashes( $escaped );
-		} else {
-			/* translators: %s: database access class HRS_MSDB */
-			$this->print_error( sprintf( __( '%s must set a database connection for use with escaping.', 'hrs-wsu-edu' ), get_class( $this ) ) );
-			$escaped = str_replace( "'", "''", $string );
-		}
+		// MS SQL syntax requires single quotes to be escaped.
+		$escaped = str_replace( "'", "''", $string );
+		$escaped = addslashes( $escaped );
 
 		return $this->add_placeholder_escape( $escaped );
 	}

--- a/includes/class-mssql-db.php
+++ b/includes/class-mssql-db.php
@@ -151,8 +151,11 @@ class MSSQL_DB {
 	 *
 	 * @since 0.2.0
 	 *
-	 * @param string $slug                 Required. A reference name for accessing this dataset.
-	 * @param array  $database_config {
+	 * @param string $database_handle      Required. A reference name for accessing this
+	 *                                     database, between 1 and 20 characters in length.
+	 *                                     Allowed characters: Lowercase alphanumeric characters,
+	 *                                     dashes and underscores, @see sanitize_key().
+	 * @param array  $config {
 	 *     Required. Array of SQL Server database connection details.
 	 *
 	 *     @type string $mssql_db_name     The name of the database to connect to.
@@ -161,14 +164,16 @@ class MSSQL_DB {
      *     @type string $mssql_db_host     The Microsoft SQL Server host.
 	 * }
 	 */
-	private function add_database( $slug, $database_config ) {
-		if ( empty( $slug ) || ! is_array( $database_config ) ) {
+	private function add_database( $database_handle, $config = array() ) {
+		if ( empty( $database_handle ) || 20 < strlen( $database_handle ) ) {
 			$this->print_error(	__( 'There is a problem with one of the datasets in "hrswp-sqlsrv-config.php."' ) );
+			return;
 		}
 
-		$slug = sanitize_key( $slug );
+		// Sanitize database handle.
+		$database_handle = sanitize_key( $database_handle );
 
-		$this->databases[ $slug ] = $database_config;
+		$this->databases[ $database_handle ] = $config;
 	}
 
 	/**

--- a/includes/class-mssql-db.php
+++ b/includes/class-mssql-db.php
@@ -241,19 +241,42 @@ class MSSQL_DB {
 	}
 
 	/**
+	 * Retrieve the database name by a given field.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string $field The field the retrieve the database name by. Accepts 'table'.
+	 * @param string $value A value for $field. A table from the desired database.
+	 * @return string|false The database label on success, false on failure.
+	 */
+	public function get_database_label_by( $field, $value ) {
+		if ( 'table' === $field ) {
+			foreach ( $this->tables as $table ) {
+				if ( in_array( $value, $table ) ) {
+					return $table['database'];
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Retrieves a database table name for use in an SQL query.
 	 *
 	 * @since 0.2.0
 	 *
 	 * @param string $table_label Required. The label for the table name to be retrieved.
-	 * @return string The database table name for use in an SQL query.
+	 * @return string|false The database table name for use in an SQL query or false on failure.
 	 */
 	public function get_table_name( $table_label ) {
-		if ( ! $table_label ) {
-			return;
+		$table = $this->tables[ $table_label ]['table_name'];
+
+		if ( ! $table ) {
+			return false;
 		}
 
-		return $this->tables[ $table_label ]['table_name'];
+		return $table;
 	}
 
 	/**
@@ -266,10 +289,15 @@ class MSSQL_DB {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string $database Required. The handle corresponding to the database to connect to.
+	 * @param string $database Required. The label corresponding to the database to connect to.
 	 * @return bool True with a successful connection, false on failure.
 	 */
 	public function mssql_db_connect( $database ) {
+		if ( ! $this->databases[ $database ] ) {
+			$this->print_error( __( 'Invalid database label provided to "mssql_db_connect"' ) );
+			return false;
+		}
+
 		// Set the MS SQL Server-style query parameters.
 		$params = array(
 			'Database' => $this->databases[ $database ]['mssql_db_name'],

--- a/includes/class-mssql-db.php
+++ b/includes/class-mssql-db.php
@@ -72,15 +72,37 @@ class MSSQL_DB {
 	 * The SQL Server database connection details.
 	 *
 	 * @since 0.2.0
-	 * @var array
-	 */
+	 * @var array {
+	 *     Array of database connection entries.
+	 *
+	 *     @type string A reference name for this database.
+	 *     @type array {
+	 *         The database credentials for the given handle.
+	 *
+	 *         @type string $mssql_db_name     The name of the database to connect to.
+	 *         @type string $mssql_db_user     The Microsoft SQL Server user for the database.
+	 *         @type string $mssql_db_password The Microsoft SQL Server user password.
+	 *         @type string $mssql_db_host     The Microsoft SQL Server host.
+	 *     }
+	 * }
+     */
 	protected $databases = array();
 
 	/**
 	 * The SQL Server database tables.
 	 *
 	 * @since 0.2.0
-	 * @var array
+	 * @var array {
+	 *     Array of table labels and database details.
+	 *
+	 *     @type string A reference name for this table.
+	 *     @type array {
+	 *         Database details for each table.
+	 *
+	 *         @type string $table_name The name of the table in the database.
+	 *         @type string $database   The reference name of the database containing the table(s).
+	 *     }
+	 * }
 	 */
 	protected $tables = array();
 

--- a/includes/class-mssql-db.php
+++ b/includes/class-mssql-db.php
@@ -219,6 +219,22 @@ class MSSQL_DB {
 	}
 
 	/**
+	 * Retrieves a database table name for use in an SQL query.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string $table_label Required. The label for the table name to be retrieved.
+	 * @return string The database table name for use in an SQL query.
+	 */
+	public function get_table_name( $table_label ) {
+		if ( ! $table_label ) {
+			return;
+		}
+
+		return $this->tables[ $table_label ]['table_name'];
+	}
+
+	/**
 	 * Connects to a database server and selects a database.
 	 *
 	 * Uses the `sqlsrv` PHP extension to open a connection to a Microsoft SQL

--- a/includes/class-mssql-db.php
+++ b/includes/class-mssql-db.php
@@ -85,7 +85,7 @@ class MSSQL_DB {
 	 *         @type string $mssql_db_host     The Microsoft SQL Server host.
 	 *     }
 	 * }
-     */
+	 */
 	protected $databases = array();
 
 	/**
@@ -138,20 +138,20 @@ class MSSQL_DB {
 		}
 
 		// Load the SQL Server DB configuration file.
-	    if ( file_exists( ABSPATH . 'hrswp-sqlsrv-config.php' ) ) {
+		if ( file_exists( ABSPATH . 'hrswp-sqlsrv-config.php' ) ) {
 
-	        // The config file exists in ABSPATH.
-	        require_once( ABSPATH . 'hrswp-sqlsrv-config.php' );
+			// The config file exists in ABSPATH.
+			require_once( ABSPATH . 'hrswp-sqlsrv-config.php' );
 
-	    } elseif ( file_exists( dirname( ABSPATH ) . '/hrswp-sqlsrv-config.php' ) ) {
+		} elseif ( file_exists( dirname( ABSPATH ) . '/hrswp-sqlsrv-config.php' ) ) {
 
-	        // The config file exists one level above ABSPATH.
-	        require_once( dirname( ABSPATH ) . '/hrswp-sqlsrv-config.php' );
+			// The config file exists one level above ABSPATH.
+			require_once( dirname( ABSPATH ) . '/hrswp-sqlsrv-config.php' );
 
-	    } else {
+		} else {
 
-	        // The config file does not exist.
-			$this->print_error(	__( 'There does not seem to be a "hrswp-sqlsrv-config.php" file. This is required for the HRSWP Sqlsrv DB plugin to work.' ) );
+			// The config file does not exist.
+			$this->print_error( __( 'There does not seem to be a "hrswp-sqlsrv-config.php" file. This is required for the HRSWP Sqlsrv DB plugin to work.' ) );
 
 		}
 	}
@@ -181,14 +181,14 @@ class MSSQL_DB {
 	 *     Required. Array of SQL Server database connection details.
 	 *
 	 *     @type string $mssql_db_name     The name of the database to connect to.
-     *     @type string $mssql_db_user     The Microsoft SQL Server user for the database.
-     *     @type string $mssql_db_password The Microsoft SQL Server user password.
-     *     @type string $mssql_db_host     The Microsoft SQL Server host.
+	 *     @type string $mssql_db_user     The Microsoft SQL Server user for the database.
+	 *     @type string $mssql_db_password The Microsoft SQL Server user password.
+	 *     @type string $mssql_db_host     The Microsoft SQL Server host.
 	 * }
 	 */
 	private function add_database( $database_handle, $config = array() ) {
 		if ( empty( $database_handle ) || 20 < strlen( $database_handle ) ) {
-			$this->print_error(	__( 'There is a problem with one of the datasets in "hrswp-sqlsrv-config.php."' ) );
+			$this->print_error( __( 'There is a problem with one of the datasets in "hrswp-sqlsrv-config.php."' ) );
 			return;
 		}
 
@@ -252,7 +252,7 @@ class MSSQL_DB {
 	public function get_database_label_by( $field, $value ) {
 		if ( 'table' === $field ) {
 			foreach ( $this->tables as $table ) {
-				if ( in_array( $value, $table ) ) {
+				if ( in_array( $value, $table, true ) ) {
 					return $table['database'];
 				}
 			}

--- a/includes/class-mssql-query.php
+++ b/includes/class-mssql-query.php
@@ -7,6 +7,7 @@
  */
 
 namespace HRSWP\SQLSRV\MSSQL_Query;
+use HRSWP\SQLSRV\MSSQL_DB;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -39,6 +40,14 @@ class MSSQL_Query {
 	public $query_vars = array();
 
 	/**
+	 * The SQL query statement.
+	 *
+	 * @since 0.2.0
+	 * @var string
+	 */
+	public $request;
+
+	/**
 	 * List of records.
 	 *
 	 * @since 0.1.0
@@ -55,16 +64,261 @@ class MSSQL_Query {
 	public $found_records = 0;
 
 	/**
+	 * Sets up the HRSWP Sqlsrv DB query.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string|array $query Query string or array of query vars.
+	 */
+	public function __construct( $query = '' ) {
+		if ( ! empty( $query ) ) {
+			$this->query( $query );
+		}
+	}
+
+	/**
+	 * Sets up and runs the HRSWP Sqlsrv DB query.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string|array $query Query string or array of query vars.
+	 * @return object[]|int[] Array of database objects or IDs.
+	 */
+	public function query( $query ) {
+		$this->init();
+		$this->query_vars = wp_parse_args( $query );
+		$this->query      = $this->query_vars;
+		return $this->get_records();
+	}
+
+	/**
 	 * Initiates object properties and sets default values.
 	 *
 	 * @since 0.1.0
 	 */
 	public function init() {
-		unset( $this->records );
 		unset( $this->query );
+		unset( $this->records );
+		unset( $this->request );
 		$this->query_vars    = array();
 		$this->found_records = 0;
 	}
 
-	// Additional query methods here.
+	/**
+	 * Parses a query string.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string|array $query {
+	 *     Required. Array or string of HRSWP Sqlsrv Query parameters.
+	 *
+	 *     @type array[] $dataset {
+	 *         One or more tables and (optional) fields to run query parameters on.
+	 *
+	 *         @type array ...$0 {
+	 *             A table and field definintion.
+	 *
+	 *             @type string          $table  Required. The handle of the table to query.
+	 *             @type string|string[] $fields Optional. The field(s) to return from the given
+	 *                                                     table. A single field (string) or multiple
+	 *                                                     fields (array). Default is all fields (*).
+	 *     }
+	 *     @type string          $order   Designates ascending or descending order of returned
+	 *                                    records. Default 'DESC'. Accepts 'ASC', 'DESC'.
+	 *     @type string|string[] $orderby Sort retrieved records by parameter. One or more options
+	 *                                    may be passed. Accepts any passed `$field` value or 'rand'.
+	 *                                    Default none.
+	 *     @type string          $groupby Group retrieved records by parameter. Default none.
+	 * }
+	 */
+	public function parse_query( $query = '' ) {
+		// The query is usually defined in the constructor call, but just in case.
+		if ( ! empty( $query ) ) {
+			$this->init();
+			$this->query_vars = wp_parse_args( $query );
+			$this->query      = $this->query_vars;
+		} elseif ( ! isset( $this->query ) ) {
+			$this->query = $this->query_vars;
+		}
+
+		// Shorthand the query vars for easier reference.
+		$qv = &$this->query_vars;
+
+		// Parse datasets.
+		if ( ! isset( $qv['dataset'] ) ) {
+			$qv['dataset'] = '';
+		} else {
+			$qv['dataset'] = array_map( array( $this, 'parse_dataset' ), $qv['dataset'] );
+		}
+
+		if ( ! isset( $qv['orderby'] ) ) {
+			$qv['orderby'] = '';
+		} elseif ( ! is_array( $qv['orderby'] ) ) {
+			$qv['orderby'] = explode( ' ', $qv['orderby'] );
+		}
+	}
+
+	/**
+	 * Standardize a 'dataset' query variable into a query-ready format.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param array $dataset {
+	 *     Required. The database table and fields to parse.
+	 *
+	 *     @type string          $table  Required. The handle of the table to query.
+	 *     @type string|string[] $fields Optional. The field(s) to return from the given
+	 *                                   table. A single field (string) or multiple
+	 *                                   fields (array). Default is all fields (*).
+	 * @return array The parsed dataset.
+	 */
+	private function parse_dataset( $dataset ) {
+		$dataset['table'] = ( isset( $dataset['table'] ) ) ? trim( $dataset['table'] ) : '';
+
+		if ( ! isset( $dataset['fields'] ) ) {
+			$dataset['fields'] = array( '*' );
+		} elseif ( ! is_array( $dataset['fields'] ) ) {
+			$dataset['fields'] = array( $dataset['fields'] );
+		}
+
+		return $dataset;
+	}
+
+	/**
+	 * Parses an 'order' query variable into ASC or DESC.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string $order The 'order' query variable.
+	 * @return string The sanitized 'order' query variable.
+	 */
+	private function parse_order( $order ) {
+		if ( ! is_string( $order ) || empty( $order ) ) {
+			return 'DESC';
+		}
+
+		if ( 'ASC' === strtoupper( $order ) ) {
+			return 'ASC';
+		} else {
+			return 'DESC';
+		}
+	}
+
+	/**
+	 * Retrieves an array of records based on query variables.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @return object[]|int[] Array of database objects or IDs.
+	 */
+	public function get_records() {
+		// Initialize the HRSWP Sqlsrv DB connector.
+		$msdb = new MSSQL_DB\MSSQL_DB();
+
+		$this->parse_query();
+
+		// Shorthand the query vars for easier reference.
+		$q = &$this->query_vars;
+
+		// Begin by clearing the SQL statement variables.
+		$field_table_array = array();
+		$fields            = '';
+		$tables            = '';
+		$join              = '';
+		$where             = '';
+		$limits            = '';
+		$groupby           = '';
+
+		// Build field => table array and tables array from query vars.
+		foreach ( $q['dataset'] as $dataset ) {
+			$table = $msdb->get_table_name( $dataset['table'] );
+			foreach ( $dataset['fields'] as $field ) {
+				$field_table_array[ $field ] = $table;
+			}
+		}
+		// Create field clauses out of field => table array.
+		$fields_array = array();
+		$tables_array = array();
+		foreach ( $field_table_array as $field => $table ) {
+			$fields_array[] = "{$table}.{$field}";
+			$tables_array[] = $table;
+		}
+		$fields = implode( ', ', $fields_array );
+		$tables = implode( ', ', array_unique( $tables_array ) );
+
+		// Build the order and orderby statement clauses.
+		$rand = ( isset( $q['orderby'] ) && 'rand' === $q['orderby'] );
+		if ( ! isset( $q['order'] ) ) {
+			$q['order'] = $rand ? '' : 'DESC';
+		} else {
+			$q['order'] = $rand ? '' : $this->parse_order( $q['order'] );
+		}
+
+		if ( empty( $q['orderby'] ) || false === $q['orderby'] || 'none' === $q['orderby'] ) {
+			$orderby = '';
+		} else {
+			$orderby_array = array();
+			// The `parse_query()` method casts any value of the 'orderby' query var to an array.
+			foreach ( $q['orderby'] as $_orderby ) {
+				$orderby = addslashes_gpc( urldecode( $_orderby ) );
+
+				if ( ! array_key_exists( $orderby, $field_table_array ) ) {
+					continue;
+				} else {
+					$orderby_clause = "{$field_table_array[ $orderby ]}.{$orderby}";
+				}
+
+				$orderby_array[] = $orderby_clause;
+			}
+			$orderby = implode( ', ', $orderby_array );
+		}
+
+		// Build the groupby statement clause.
+		if ( empty( $q['groupby'] ) || false === $q['groupby'] || 'none' === $q['groupby'] ) {
+			$groupby = '';
+		} else {
+			$groupby = addslashes_gpc( urldecode( $q['groupby'] ) );
+			$groupby = "{$field_table_array[ $groupby ]}.{$groupby}";
+		}
+
+		if ( ! empty( $groupby ) ) {
+			$groupby = 'GROUP BY ' . $groupby;
+		}
+		if ( ! empty( $orderby ) ) {
+			$orderby = 'ORDER BY ' . $orderby;
+		}
+
+		$this->request = $msdb->prepare(
+			'SELECT %s FROM %s %s WHERE 1=1 %s %s %s',
+			array(
+				$fields,
+				$tables,
+				$join,
+				$where,
+				$groupby,
+				$orderby,
+			)
+		);
+
+		// Select database based on table from query.
+		$database = $msdb->get_database_label_by( 'table', $tables_array[0] );
+
+		// Connect to the database.
+		if ( $msdb->mssql_db_connect( $database ) ) {
+			// Make the request.
+			$this->records = $msdb->get_results( $this->request );
+
+			// Disconnect from the database and clean up.
+			$msdb->clean();
+
+			$this->found_records = count( $this->records );
+		}
+
+		if ( ! $this->records ) {
+			$this->found_records = 0;
+			$this->records       = array();
+		}
+
+		return $this->records;
+	}
 }

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -139,6 +139,9 @@ class Setup {
 	private function includes() {
 		// The Microsoft SQL Server database connection class.
 		require __DIR__ . '/class-mssql-db.php';
+
+		// The Microsoft SQL Server query class.
+		require __DIR__ . '/class-mssql-query.php';
 	}
 
 	/**

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -201,6 +201,6 @@ class Setup {
 			'<code>hrswp-sqlsrv-config.php</code>'
 		);
 
-	    printf( '<div class="notice notice-error"><p>%s</p></div>', $message );
+		printf( '<div class="notice notice-error"><p>%s</p></div>', $message );
 	}
 }

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -171,5 +171,33 @@ class Setup {
 
 			update_option( self::$slug . '_plugin-status', $status );
 		}
+
+		// Check for the HRSWP Sqlsrv configuration file.
+		if (
+			! file_exists( ABSPATH . 'hrswp-sqlsrv-config.php' ) &&
+			! file_exists( dirname( ABSPATH ) . '/hrswp-sqlsrv-config.php' )
+		) {
+			// Warn if the HRSWP Sqlsrv configuration file can't be found.
+			add_action( 'admin_notices', array( $this, 'notice__missing_config_file' ) );
+		}
+	}
+
+	/**
+	 * Displays an error message in the WP Admin area if the plugin config file is missing.
+	 *
+	 * The HRSWP Sqlsrv DB plugin relies on a 'hrswp-sqlsrv-config.php' file
+	 * existing alongside the 'wp-config.php' file to store details for the
+	 * external SQL Server databases.
+	 *
+	 * @since 0.2.0
+	 */
+	public function notice__missing_config_file() {
+		$message = sprintf(
+			/* translators: %s: hrswp-sqlsrv-config.php */
+			__( 'ERROR: There doesn\'t seem to be a %s file. This is required for the HRSWP Sqlsrv DB plugin to work.' ),
+			'<code>hrswp-sqlsrv-config.php</code>'
+		);
+
+	    printf( '<div class="notice notice-error"><p>%s</p></div>', $message );
 	}
 }


### PR DESCRIPTION
## Description

Adjust handling of database credentials: move database and table configuration to a dedicated restricted file alongside `wp-config` and use class methods to parse that configuration as needed. Use database and table aliases in the query methods to keep them more private and add a dedicated query class to handle queries instead of requiring user-created SQL statements.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
