### PR TITLE
Fix nurses salary display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
-## 0.4.0-rc.1 (:construction: 2019-12-17)
+## 0.4.0-rc.2 (:construction: 2019-12-18)
 
 ### Fixed
 
+- :bug: Fix #9 Add missing "years of experience" row to the nurses salary data tables.
 - :alien: Rename MS SQL connector class from `mssql` to `sqlsrv` to resolve confusion with 'mssql' PHP extension removed in PHP 7.0.
 - :warning: Fix php lint function inspection warning.
 - :warning: Fix php lint unused variable warnings.

--- a/build/blocks/salary-data.php
+++ b/build/blocks/salary-data.php
@@ -117,6 +117,11 @@ function render( $attributes ) {
 	}
 	$table_head .= '</tr>';
 
+	// The "Nurses" salary data needs supplemental "Years of experience" data inserted.
+	if ( strstr( $attributes['queryTable'], 'nurses' ) ) {
+		$table_head .= nurses_years_experience_row( $attributes['queryTable'] );
+	}
+
 	foreach ( $data as $row ) {
 		$table_body .= '<tr>';
 
@@ -147,6 +152,167 @@ function render( $attributes ) {
 		$table_head,
 		$table_body
 	);
+}
+
+/**
+ * Generates a years of experience row for the four Nurses tables.
+ *
+ * The Nurses data from the database is missing a required "years of experience" header row, so
+ * we need to add it manually. It is different for all four tables.
+ *
+ * @since 0.4.1
+ *
+ * @param string $query_table The name of the table being queried.
+ * @return string The formatted HTML table row with the years of experience data.
+ */
+function nurses_years_experience_row( $query_table ) {
+	$experience_row = '<tr><th><abbr title="' . __( 'Years of experience', 'hrswp-sqlsrv-db' ) . '">YRSx</abbr></th>';
+
+	// Nurses Group A, Steps A-M.
+	if ( strstr( $query_table, 'nurses-a-am' ) ) {
+		foreach ( range( 'A', 'M' ) as $letter ) {
+			switch ( $letter ) {
+				case 'E':
+					$years = '0';
+					break;
+				case 'G':
+					$years = '1';
+					break;
+				case 'I':
+					$years = '2';
+					break;
+				case 'K':
+					$years = '3';
+					break;
+				case 'L':
+					$years = '4';
+					break;
+				case 'M':
+					$years = '5';
+					break;
+				default:
+					$years = '';
+					break;
+			}
+
+			$experience_row .= "<th>{$years}</th>";
+		}
+	}
+
+	// Nurses Group A, Steps N-U.
+	if ( strstr( $query_table, 'nurses-a-nu' ) ) {
+		foreach ( range( 'N', 'U' ) as $letter ) {
+			switch ( $letter ) {
+				case 'N':
+					$years = '6';
+					break;
+				case 'O':
+					$years = '7';
+					break;
+				case 'P':
+					$years = '8';
+					break;
+				case 'Q':
+					$years = '12';
+					break;
+				case 'R':
+					$years = '15';
+					break;
+				case 'S':
+					$years = '18';
+					break;
+				case 'T':
+					$years = '20';
+					break;
+				case 'U':
+					$years = '26';
+					break;
+				default:
+					$years = '';
+					break;
+			}
+
+			$experience_row .= "<th>{$years}</th>";
+		}
+	}
+
+	// Nurses Group B, Steps A-M.
+	if ( strstr( $query_table, 'nurses-b-am' ) ) {
+		foreach ( range( 'A', 'M' ) as $letter ) {
+			switch ( $letter ) {
+				case 'A':
+					$years = '0';
+					break;
+				case 'C':
+					$years = '1';
+					break;
+				case 'E':
+					$years = '2';
+					break;
+				case 'G':
+					$years = '3';
+					break;
+				case 'I':
+					$years = '4';
+					break;
+				case 'K':
+					$years = '5';
+					break;
+				case 'L':
+					$years = '6';
+					break;
+				case 'M':
+					$years = '7';
+					break;
+				default:
+					$years = '';
+					break;
+			}
+
+			$experience_row .= "<th>{$years}</th>";
+		}
+	}
+
+	// Nurses Group B, Steps N-U.
+	if ( strstr( $query_table, 'nurses-b-nu' ) ) {
+		foreach ( range( 'N', 'U' ) as $letter ) {
+			switch ( $letter ) {
+				case 'N':
+					$years = '8';
+					break;
+				case 'O':
+					$years = '9';
+					break;
+				case 'P':
+					$years = '10';
+					break;
+				case 'Q':
+					$years = '12';
+					break;
+				case 'R':
+					$years = '15';
+					break;
+				case 'S':
+					$years = '18';
+					break;
+				case 'T':
+					$years = '20';
+					break;
+				case 'U':
+					$years = '26';
+					break;
+				default:
+					$years = '';
+					break;
+			}
+
+			$experience_row .= "<th>{$years}</th>";
+		}
+	}
+
+	$experience_row .= '</tr>';
+
+	return $experience_row;
 }
 
 /**

--- a/hrswp-sqlsrv-db.php
+++ b/hrswp-sqlsrv-db.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: HRSWP Sqlsrv DB
- * Version: 0.4.0-rc.1
+ * Version: 0.4.0-rc.2
  * Description: A WSU HRS WordPress plugin to connect to and query external Microsoft SQL Server databases.
  * Author: Adam Turner, washingtonstateuniversity
  * Author URI: https://hrs.wsu.edu/

--- a/src/blocks/salary-data/index.php
+++ b/src/blocks/salary-data/index.php
@@ -117,6 +117,11 @@ function render( $attributes ) {
 	}
 	$table_head .= '</tr>';
 
+	// The "Nurses" salary data needs supplemental "Years of experience" data inserted.
+	if ( strstr( $attributes['queryTable'], 'nurses' ) ) {
+		$table_head .= nurses_years_experience_row( $attributes['queryTable'] );
+	}
+
 	foreach ( $data as $row ) {
 		$table_body .= '<tr>';
 
@@ -147,6 +152,167 @@ function render( $attributes ) {
 		$table_head,
 		$table_body
 	);
+}
+
+/**
+ * Generates a years of experience row for the four Nurses tables.
+ *
+ * The Nurses data from the database is missing a required "years of experience" header row, so
+ * we need to add it manually. It is different for all four tables.
+ *
+ * @since 0.4.0
+ *
+ * @param string $query_table The name of the table being queried.
+ * @return string The formatted HTML table row with the years of experience data.
+ */
+function nurses_years_experience_row( $query_table ) {
+	$experience_row = '<tr><th><abbr title="' . __( 'Years of experience', 'hrswp-sqlsrv-db' ) . '">YRSx</abbr></th>';
+
+	// Nurses Group A, Steps A-M.
+	if ( strstr( $query_table, 'nurses-a-am' ) ) {
+		foreach ( range( 'A', 'M' ) as $letter ) {
+			switch ( $letter ) {
+				case 'E':
+					$years = '0';
+					break;
+				case 'G':
+					$years = '1';
+					break;
+				case 'I':
+					$years = '2';
+					break;
+				case 'K':
+					$years = '3';
+					break;
+				case 'L':
+					$years = '4';
+					break;
+				case 'M':
+					$years = '5';
+					break;
+				default:
+					$years = '';
+					break;
+			}
+
+			$experience_row .= "<th>{$years}</th>";
+		}
+	}
+
+	// Nurses Group A, Steps N-U.
+	if ( strstr( $query_table, 'nurses-a-nu' ) ) {
+		foreach ( range( 'N', 'U' ) as $letter ) {
+			switch ( $letter ) {
+				case 'N':
+					$years = '6';
+					break;
+				case 'O':
+					$years = '7';
+					break;
+				case 'P':
+					$years = '8';
+					break;
+				case 'Q':
+					$years = '12';
+					break;
+				case 'R':
+					$years = '15';
+					break;
+				case 'S':
+					$years = '18';
+					break;
+				case 'T':
+					$years = '20';
+					break;
+				case 'U':
+					$years = '26';
+					break;
+				default:
+					$years = '';
+					break;
+			}
+
+			$experience_row .= "<th>{$years}</th>";
+		}
+	}
+
+	// Nurses Group B, Steps A-M.
+	if ( strstr( $query_table, 'nurses-b-am' ) ) {
+		foreach ( range( 'A', 'M' ) as $letter ) {
+			switch ( $letter ) {
+				case 'A':
+					$years = '0';
+					break;
+				case 'C':
+					$years = '1';
+					break;
+				case 'E':
+					$years = '2';
+					break;
+				case 'G':
+					$years = '3';
+					break;
+				case 'I':
+					$years = '4';
+					break;
+				case 'K':
+					$years = '5';
+					break;
+				case 'L':
+					$years = '6';
+					break;
+				case 'M':
+					$years = '7';
+					break;
+				default:
+					$years = '';
+					break;
+			}
+
+			$experience_row .= "<th>{$years}</th>";
+		}
+	}
+
+	// Nurses Group B, Steps N-U.
+	if ( strstr( $query_table, 'nurses-b-nu' ) ) {
+		foreach ( range( 'N', 'U' ) as $letter ) {
+			switch ( $letter ) {
+				case 'N':
+					$years = '8';
+					break;
+				case 'O':
+					$years = '9';
+					break;
+				case 'P':
+					$years = '10';
+					break;
+				case 'Q':
+					$years = '12';
+					break;
+				case 'R':
+					$years = '15';
+					break;
+				case 'S':
+					$years = '18';
+					break;
+				case 'T':
+					$years = '20';
+					break;
+				case 'U':
+					$years = '26';
+					break;
+				default:
+					$years = '';
+					break;
+			}
+
+			$experience_row .= "<th>{$years}</th>";
+		}
+	}
+
+	$experience_row .= '</tr>';
+
+	return $experience_row;
 }
 
 /**


### PR DESCRIPTION
## Description

Adds a missing row of data to the nurses salary range tables. The "years of experience" information is not in the source database, so it needs to be added manually.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
